### PR TITLE
v2.0: Multi-class melee and ranged swing timer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,8 +22,8 @@ body:
       label: Steps to Reproduce
       description: How can we reproduce this issue?
       placeholder: |
-        1. Equip a ranged weapon
-        2. Fire an Auto Shot
+        1. Enter combat
+        2. Observe swing timer bars
         3. ...
     validations:
       required: true
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Addon Version
       description: Found in the addon list in-game or the TOC file.
-      placeholder: "e.g. 1.1"
+      placeholder: "e.g. 2.0"
     validations:
       required: true
   - type: input

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ Closes #
 ## Test Plan
 
 - [ ] Loaded in-game without Lua errors
-- [ ] Timer appears and tracks Auto Shot correctly
+- [ ] Swing timer bars appear and track correctly (MH, OH, Ranged as applicable)
 - [ ] Frame drag and position save works
 - [ ] No regressions on tested behavior

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '**'
+      - 'v*'
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# 🏹 SwangThang
+# ⚔️ SwangThang
 
-Hunter Auto Shot timer for World of Warcraft: TBC Classic.
+Melee and ranged swing timer for World of Warcraft: TBC Classic.
 
-**SwangThang** is a specialized swing timer addon built to accurately visualize the unique Auto Shot mechanics of TBC Classic — including the hidden cast window and movement penalty retry behavior. It gives Hunters the precise timing feedback needed to maximize ranged DPS without clipping shots.
+**SwangThang** tracks your white-hit swing timers across all attack slots — main hand, off hand, and ranged — giving every physical DPS class the precise timing feedback needed to maximize damage. It handles all the quirks of TBC melee: NMA abilities, dual-wield desync, parry haste, extra attack suppression, haste rescaling, and Druid form shifts.
 
 ---
 
 ## ✨ Key Features
 
-- ⏱️ **Dynamic Swing Calculation** — Real-time updates based on your current ranged weapon speed, accounting for haste procs like *Quick Shots*, *Rapid Fire*, and *Dragonspine Trophy*
-- 🔴 **0.5s Cast Window** — The bar turns red during the final 0.5 seconds of the swing, signaling the hidden cast time where movement will clip the shot
-- 🟢 **Movement Logic** — Green bar means safe to move (cooldown phase); red bar means standing still is required. Moving during red triggers the TBC retry mechanic — the timer resets to the start of the cast window
-- 📡 **Latency Compensation** — Automatically adjusts swing start time based on your current World Latency (`GetNetStats`)
-- 🖱️ **Draggable Interface** — Hold Left Click to drag the bar anywhere on screen. Position is saved automatically between sessions
+- ⚔️ **All Melee Classes** — Warrior, Rogue, Paladin, Shaman, Druid, and Hunter all get accurate swing bars tuned to their class mechanics
+- 🏹 **Hunter Auto Shot** — Preserved from v1.x: 0.5s cast window visualization, movement penalty retry logic, and latency compensation
+- 🔄 **Dual-Wield Tracking** — Independent MH and OH timers with correct isOffHand routing; OH bar anchors below MH automatically
+- 🎯 **NMA Detection** — Heroic Strike, Cleave, Maul, and Raptor Strike reset the MH timer on cast via both CLEU and `UNIT_SPELLCAST_SUCCEEDED`
+- ⚡ **Haste Rescaling** — Remaining time rescales proportionally when weapon speed changes mid-swing (Slice and Dice, Rapid Fire, haste procs)
+- 🛡️ **Parry Haste** — Incoming parries reduce your MH remaining time by 40% of weapon speed (floored at 20%)
+- 🔀 **Extra Attack Suppression** — Sword Spec and Windfury Weapon extra attacks are absorbed cleanly without desyncing the timer
+- 🐾 **Druid Forms** — Form shifts reset the MH timer; bar label shows current form (*Cat*, *Bear*, *DireBear*, *Caster*)
+- 🔑 **Seal Twist Zone** — Ret Paladins get a gold overlay marking the 0.4s window before each MH swing for seal-twisting timing
 
 ---
 
@@ -23,36 +27,66 @@ Hunter Auto Shot timer for World of Warcraft: TBC Classic.
    ```
    World of Warcraft\_anniversary_\Interface\AddOns\SwangThang\
    ```
-3. Log in and start shooting
+3. Log in and start swinging
 
 ---
 
 ## 🖥️ Usage
 
-The bar is hidden until you fire your first Auto Shot.
+Bars appear automatically when you enter combat. The ranged bar (Hunter) also appears when auto-shot mode starts.
 
-| Color | Meaning |
-|-------|---------|
-| 🟢 Green | Auto Shot cooldown — safe to move |
-| 🔴 Red | Auto Shot cast window — **do not move** |
+| Bar | Color | Meaning |
+|-----|-------|---------|
+| Ranged | 🟢 Green | Auto Shot cooldown — safe to move |
+| Ranged | 🔴 Red | Cast window — **do not move** |
+| Main Hand | 🟡 Gold | MH swing cooldown |
+| Off Hand | 🟢 Green | OH swing cooldown |
 
-A spark indicator shows current progress along the bar. The timer resets if you cast a hard-cast ability (like Aimed Shot) or stop attacking.
+A spark indicator shows current progress. **Left-click drag** to reposition any bar. Positions persist across sessions.
+
+---
+
+## 🎮 Class Support
+
+| Class | Bars | Special |
+|-------|------|---------|
+| Hunter | Ranged + MH | 0.5s cast window, movement clipping, latency compensation |
+| Warrior | MH + OH | HS/Cleave/Slam NMA detection |
+| Rogue | MH + OH | Full dual-wield |
+| Paladin | MH | Gold seal-twist zone overlay |
+| Enhancement Shaman | MH + OH | Full dual-wield |
+| Feral Druid | MH | Form-label bar, reset on shift |
+| Mage / Priest / Warlock | — | No bars (no auto-attack rotation) |
 
 ---
 
 ## 🔧 Configuration
 
-No slash commands. The frame is unlocked by default for dragging.
+No slash commands. All settings save automatically.
 
 | Setting | Storage |
 |---------|---------|
-| Bar position | Saved in `HunterTimerDB` (persists across sessions) |
+| Bar positions | `SwangThangDB.positions` |
+| MH / OH visibility | `SwangThangDB.showMH` / `showOH` |
 
 ---
 
 ## 📋 Changelog
 
-### 1.1.1 *(Latest)*
+### 2.0 *(Latest)*
+
+- 🆕 Full melee swing timer for all physical DPS classes
+- 🆕 Dual-wield MH + OH independent tracking
+- 🆕 NMA ability detection (Heroic Strike, Cleave, Maul, Raptor Strike, Slam)
+- 🆕 Extra attack suppression (Sword Spec, Windfury Weapon)
+- 🆕 Parry haste support
+- 🆕 Haste rescaling for all melee bars
+- 🆕 Druid form-shift reset with form label
+- 🆕 Ret Paladin seal-twist zone overlay
+- 🆕 5-module architecture (Constants / State / UI / ClassMods / Bootstrap)
+- ✨ SavedVariables migrated to `SwangThangDB` (nested positions)
+
+### 1.1.1
 
 - ✨ Updated README with standard formatting and installation path
 - 🆕 Added CI release workflow (GitHub + CurseForge)
@@ -60,9 +94,9 @@ No slash commands. The frame is unlocked by default for dragging.
 
 ### 1.1
 
-- 🆕 Initial public release
-- 🆕 Dynamic swing timer with haste proc support (*Quick Shots*, *Rapid Fire*, *Dragonspine Trophy*)
-- 🆕 0.5s cast window visualization with color-coded red/green bar
+- 🆕 Initial public release — Hunter Auto Shot timer
+- 🆕 Dynamic swing timer with haste proc support
+- 🆕 0.5s cast window visualization
 - 🆕 Movement penalty and TBC retry mechanic simulation
 - 🆕 Latency compensation via `GetNetStats`
 - 🆕 Draggable frame with persistent position storage

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ No slash commands. All settings save automatically.
 
 ---
 
+## 💬 Feedback
+
+Found a bug? Have an idea? Open an issue on [GitHub Issues](https://github.com/chefm4tt/SwangThang/issues) — bug reports and feature requests are welcome. v2.0 is the first release with full melee support, so feedback from all class players is especially appreciated.
+
+---
+
 ## 📋 Changelog
 
 ### 2.0 *(Latest)*

--- a/SwangThang.lua
+++ b/SwangThang.lua
@@ -1,248 +1,194 @@
 local addonName, ns = ...
 
--- ----------------------------------------------------------------------------
--- Configuration & Constants
--- ----------------------------------------------------------------------------
-local BAR_WIDTH = 200
-local BAR_HEIGHT = 20
-local CAST_WINDOW = 0.5 -- The hidden cast time for Auto Shot in TBC
-local AUTO_SHOT_ID = 75
+-- ============================================================
+-- Bootstrap: event frame, SavedVariables init, dispatch
+-- ============================================================
+-- This file wires everything together. Logic lives in:
+--   SwangThang_Constants.lua  — spell IDs, class config, defaults
+--   SwangThang_State.lua      — detection engine, timer state
+--   SwangThang_UI.lua         — bars, visuals, drag, show/hide
+--   SwangThang_ClassMods.lua  — class-specific overlays
 
--- ----------------------------------------------------------------------------
--- Frame Setup
--- ----------------------------------------------------------------------------
-local f = CreateFrame("StatusBar", "HunterTimerFrame", UIParent)
-f:SetSize(BAR_WIDTH, BAR_HEIGHT)
-f:SetPoint("CENTER", UIParent, "CENTER", 0, -100)
-f:SetMovable(true)
-f:EnableMouse(true)
-f:RegisterForDrag("LeftButton")
-f:SetClampedToScreen(true)
+-- ============================================================
+-- Runtime globals
+-- ============================================================
+ns.isMoving        = false
+ns.playerClass     = nil
+ns.classConfig     = nil
+ns.druidFormChangeTime = nil
 
--- Visuals
-f:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
-f:SetStatusBarColor(0, 1, 0, 1) -- Green for cooldown phase
-
-local bg = f:CreateTexture(nil, "BACKGROUND")
-bg:SetAllPoints(true)
-bg:SetColorTexture(0, 0, 0, 0.5)
-
-local border = f:CreateTexture(nil, "OVERLAY")
-border:SetColorTexture(0, 0, 0, 1)
-border:SetPoint("TOPLEFT", -1, 1)
-border:SetPoint("BOTTOMRIGHT", 1, -1)
-border:SetDrawLayer("OVERLAY", -1) -- Behind the spark/text
-
--- The Red "Cast" Window Overlay
-local castZone = f:CreateTexture(nil, "ARTWORK")
-castZone:SetColorTexture(1, 0, 0, 0.4) -- Red overlay
-castZone:SetPoint("TOPRIGHT")
-castZone:SetPoint("BOTTOMRIGHT")
-castZone:SetWidth(0) -- Set dynamically
-
-local spark = f:CreateTexture(nil, "OVERLAY")
-spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
-spark:SetBlendMode("ADD")
-spark:SetWidth(20)
-spark:SetHeight(BAR_HEIGHT * 2.2)
-spark:SetPoint("CENTER", f, "LEFT", 0, 0)
-
-local text = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-text:SetPoint("CENTER")
-text:SetText("Auto Shot")
-
--- ----------------------------------------------------------------------------
--- State Variables
--- ----------------------------------------------------------------------------
-local lastShotTime = 0
-local swingDuration = 2.0
-local isMoving = false
-local isSwinging = false
-
--- ----------------------------------------------------------------------------
--- Helper Functions
--- ----------------------------------------------------------------------------
-
--- Calculates current ranged weapon speed (Haste Math)
--- Returns: speed (float)
-local function GetCurrentWeaponSpeed()
-	-- UnitRangedDamage returns speed in seconds as the first argument.
-	-- This native function accounts for Haste, Rapid Fire, Quiver, etc.
-	local speed = UnitRangedDamage("player")
-	if speed and speed > 0 then
-		return speed
+-- ============================================================
+-- SavedVariables migration
+-- ============================================================
+local function MigrateDB()
+	-- v2: SwangThangDB with nested positions
+	-- Migrate from v1: HunterTimerDB = {point, relativePoint, x, y}
+	if HunterTimerDB and not SwangThangDB then
+		SwangThangDB = {
+			version   = 2,
+			showMH    = true,
+			showOH    = true,
+			positions = {
+				mh     = ns.DB_DEFAULTS.positions.mh,
+				oh     = ns.DB_DEFAULTS.positions.oh,
+				ranged = {
+					point        = HunterTimerDB.point        or "CENTER",
+					relativePoint = HunterTimerDB.relativePoint or "CENTER",
+					x            = HunterTimerDB.x            or 0,
+					y            = HunterTimerDB.y            or -100,
+				},
+			},
+		}
+		HunterTimerDB = nil  -- clear legacy SavedVariable
 	end
-	return 2.0 -- Fallback
-end
 
-local function UpdateCastZoneVisual()
-	if swingDuration > 0 then
-		-- Calculate width of the 0.5s window relative to total swing time
-		local width = (CAST_WINDOW / swingDuration) * BAR_WIDTH
-		-- Clamp width to not exceed bar width
-		width = math.min(width, BAR_WIDTH)
-		castZone:SetWidth(width)
+	-- Fresh install
+	if not SwangThangDB then
+		SwangThangDB = {
+			version   = ns.DB_DEFAULTS.version,
+			showMH    = ns.DB_DEFAULTS.showMH,
+			showOH    = ns.DB_DEFAULTS.showOH,
+			positions = {
+				mh     = { point = ns.DB_DEFAULTS.positions.mh.point,     relativePoint = ns.DB_DEFAULTS.positions.mh.relativePoint,     x = ns.DB_DEFAULTS.positions.mh.x,     y = ns.DB_DEFAULTS.positions.mh.y     },
+				oh     = { point = ns.DB_DEFAULTS.positions.oh.point,     relativePoint = ns.DB_DEFAULTS.positions.oh.relativePoint,     x = ns.DB_DEFAULTS.positions.oh.x,     y = ns.DB_DEFAULTS.positions.oh.y     },
+				ranged = { point = ns.DB_DEFAULTS.positions.ranged.point, relativePoint = ns.DB_DEFAULTS.positions.ranged.relativePoint, x = ns.DB_DEFAULTS.positions.ranged.x, y = ns.DB_DEFAULTS.positions.ranged.y },
+			},
+		}
+	end
+
+	-- Fill any missing fields for upgrades
+	SwangThangDB.version = SwangThangDB.version or 2
+	SwangThangDB.showMH  = (SwangThangDB.showMH  ~= false)
+	SwangThangDB.showOH  = (SwangThangDB.showOH  ~= false)
+	SwangThangDB.positions = SwangThangDB.positions or {}
+	for slot, def in pairs(ns.DB_DEFAULTS.positions) do
+		if not SwangThangDB.positions[slot] then
+			SwangThangDB.positions[slot] = { point = def.point, relativePoint = def.relativePoint, x = def.x, y = def.y }
+		end
 	end
 end
 
-local function ResetTimer()
-	isSwinging = false
-	f:SetValue(0)
-	spark:SetPoint("CENTER", f, "LEFT", 0, 0)
-	f:SetAlpha(0)
+-- ============================================================
+-- Initialization
+-- ============================================================
+local function OnAddonLoaded()
+	MigrateDB()
+
+	-- Detect class once
+	local _, class = UnitClass("player")
+	ns.playerClass = class
+	ns.classConfig = ns.CLASS_CONFIG[class] or { ranged = false, melee = false, dualWield = false }
+
+	-- Class-specific mods first (registers callbacks before bars are created)
+	ns.InitClassMods()
+
+	-- Create bars for this class
+	ns.InitBars()
 end
 
-local function StartSwing()
-	-- Latency Adjustment
-	local _, _, _, latencyWorld = GetNetStats()
-	local latencySec = (latencyWorld or 0) / 1000
+-- ============================================================
+-- Event frame
+-- ============================================================
+local frame = CreateFrame("Frame", "SwangThangFrame", UIParent)
 
-	lastShotTime = GetTime() - latencySec
-	swingDuration = GetCurrentWeaponSpeed()
-	
-	f:SetMinMaxValues(0, swingDuration)
-	UpdateCastZoneVisual()
-	
-	isSwinging = true
-	f:SetAlpha(1)
+-- Register events conditionally in ADDON_LOADED once class is known
+local function RegisterEvents()
+	local cfg = ns.classConfig or {}
+
+	-- Core events for all classes
+	frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+	frame:RegisterEvent("ADDON_LOADED")
+
+	if cfg.melee then
+		frame:RegisterEvent("UNIT_ATTACK_SPEED")
+		frame:RegisterEvent("PLAYER_REGEN_DISABLED")
+		frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+		frame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
+		frame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+	end
+
+	if cfg.ranged then
+		frame:RegisterEvent("UNIT_SPELLCAST_START")
+		frame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+		frame:RegisterEvent("START_AUTOREPEAT_SPELL")
+		frame:RegisterEvent("STOP_AUTOREPEAT_SPELL")
+		frame:RegisterEvent("PLAYER_STARTED_MOVING")
+		frame:RegisterEvent("PLAYER_STOPPED_MOVING")
+		frame:RegisterEvent("PLAYER_REGEN_DISABLED")
+		frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+	end
+
+	if cfg.melee and ns.playerClass == "WARRIOR" then
+		frame:RegisterEvent("UNIT_SPELLCAST_START")
+		frame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+	end
+
+	if cfg.melee and ns.playerClass == "DRUID" then
+		frame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
+	end
 end
 
--- ----------------------------------------------------------------------------
--- Event Handling
--- ----------------------------------------------------------------------------
-f:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-f:RegisterEvent("PLAYER_STARTED_MOVING")
-f:RegisterEvent("PLAYER_STOPPED_MOVING")
-f:RegisterEvent("UNIT_SPELLCAST_START")
-f:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-f:RegisterEvent("ADDON_LOADED")
-f:RegisterEvent("PLAYER_REGEN_ENABLED")
+frame:RegisterEvent("ADDON_LOADED")
 
-f:SetScript("OnEvent", function(self, event, ...)
-	if event == "COMBAT_LOG_EVENT_UNFILTERED" then
-		local _, subEvent, _, sourceGUID, _, _, _, _, _, _, _, spellId = CombatLogGetCurrentEventInfo()
-		
-		if sourceGUID == UnitGUID("player") and subEvent == "SPELL_CAST_SUCCESS" then
-			if spellId == AUTO_SHOT_ID then
-				StartSwing()
-			end
+frame:SetScript("OnEvent", function(self, event, ...)
+	if event == "ADDON_LOADED" then
+		local name = ...
+		if name == addonName then
+			OnAddonLoaded()
+			RegisterEvents()
 		end
 
+	elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
+		ns.HandleCLEU()
+
+	elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+		ns.HandleSpellcastSucceeded(...)
+
 	elseif event == "PLAYER_STARTED_MOVING" then
-		isMoving = true
+		ns.isMoving = true
 
 	elseif event == "PLAYER_STOPPED_MOVING" then
-		isMoving = false
+		ns.isMoving = false
 
 	elseif event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_CHANNEL_START" then
 		local unit, _, spellId = ...
-		if unit == "player" then
-			-- If casting Aimed Shot or other hard casts, Auto Shot is usually clipped/reset.
-			-- We reset the visual timer to indicate the swing is interrupted.
-			-- Note: Steady Shot does not clip Auto Shot in the same way in later expansions, 
-			-- but in TBC hard casts usually reset the swing timer.
-			if spellId ~= AUTO_SHOT_ID then 
-				ResetTimer()
-			end
+		if unit == "player" and spellId ~= ns.AUTO_SHOT_ID then
+			ns.ResetTimer("ranged")
+			if ns.rangedBar then ns.rangedBar:SetAlpha(0) end
 		end
 
-	elseif event == "ADDON_LOADED" then
-		local name = ...
-		if name == "SwangThang" then
-			if HunterTimerDB then
-				f:ClearAllPoints()
-				f:SetPoint(HunterTimerDB.point, UIParent, HunterTimerDB.relativePoint, HunterTimerDB.x, HunterTimerDB.y)
-			else
-				HunterTimerDB = { point = "CENTER", relativePoint = "CENTER", x = 0, y = -100 }
-			end
-		end
+	elseif event == "START_AUTOREPEAT_SPELL" then
+		-- Hunter starts auto-shooting
+		if ns.rangedBar then ns.rangedBar:SetAlpha(1) end
+
+	elseif event == "STOP_AUTOREPEAT_SPELL" then
+		ns.ResetTimer("ranged")
+		if ns.rangedBar then ns.rangedBar:SetAlpha(0) end
+
+	elseif event == "PLAYER_REGEN_DISABLED" then
+		ns.ShowBars()
 
 	elseif event == "PLAYER_REGEN_ENABLED" then
-		-- Optional: Hide out of combat if desired, keeping it simple for now
-		-- ResetTimer() 
-	end
-end)
+		ns.HideBars()
+		ns.ResetTimer("mh")
+		ns.ResetTimer("oh")
+		ns.ResetTimer("ranged")
 
--- ----------------------------------------------------------------------------
--- OnUpdate Logic
--- ----------------------------------------------------------------------------
-f:SetScript("OnUpdate", function(self, elapsed)
-	if not isSwinging then return end
+	elseif event == "PLAYER_EQUIPMENT_CHANGED" then
+		ns.UpdateOHBar()
 
-	local now = GetTime()
-	
-	-- 1. Dynamic Swing Calculation
-	-- Update duration constantly to account for procs (DST, Rapid Fire, etc)
-	local currentSpeed = GetCurrentWeaponSpeed()
-	
-	-- If speed changed significantly, update the max value
-	if math.abs(swingDuration - currentSpeed) > 0.01 then
-		swingDuration = currentSpeed
-		f:SetMinMaxValues(0, swingDuration)
-		UpdateCastZoneVisual()
-	end
-
-	-- 2. Calculate Time Remaining
-	-- The "Cast Window" starts at (swingDuration - CAST_WINDOW)
-	local cooldownEndTime = lastShotTime + swingDuration - CAST_WINDOW
-	
-	-- 3. Movement & Clipping Logic
-	if now >= cooldownEndTime then
-		-- We are in the 0.5s "Hidden Cast" window
-		if isMoving then
-			-- If moving during the cast window, the shot is clipped/delayed.
-			-- We push the lastShotTime forward so that the timer "pauses" 
-			-- exactly at the start of the cast window (0.5s remaining).
-			-- This satisfies the "Retry Mechanic": as soon as we stop, 
-			-- lastShotTime stops shifting, and we have exactly 0.5s left to fire.
-			
-			lastShotTime = now - (swingDuration - CAST_WINDOW)
+	elseif event == "UPDATE_SHAPESHIFT_FORM" then
+		-- Druid form label update handled via classmod callback
+		if ns.OnDruidFormChange then
+			-- Fire with current form; exact aura handled via CLEU
+			local form = GetShapeshiftForm and GetShapeshiftForm() or 0
+			if form == 0 then
+				ns.OnDruidFormChange(0)
+			end
 		end
-		
-		-- Visual: Change color to Red to indicate Cast Phase
-		f:SetStatusBarColor(1, 0, 0, 1)
-	else
-		-- Visual: Green for Cooldown Phase
-		f:SetStatusBarColor(0, 1, 0, 1)
-	end
-
-	local timeElapsed = now - lastShotTime
-	local timeRemaining = swingDuration - timeElapsed
-
-	-- Clamp visual to 0
-	if timeRemaining < 0 then timeRemaining = 0 end
-
-	-- Update Bar
-	f:SetValue(timeElapsed)
-
-	-- Update Spark
-	local sparkPos = (timeElapsed / swingDuration) * BAR_WIDTH
-	if sparkPos > BAR_WIDTH then sparkPos = BAR_WIDTH end
-	spark:SetPoint("CENTER", f, "LEFT", sparkPos, 0)
-
-	-- Update Text
-	text:SetText(string.format("%.1f", timeRemaining))
-end)
-
--- ----------------------------------------------------------------------------
--- Drag Handling
--- ----------------------------------------------------------------------------
-f:SetScript("OnMouseDown", function(self, button)
-	if button == "LeftButton" and not self.isMoving then
-		self:StartMoving()
-		self.isMoving = true
 	end
 end)
 
-f:SetScript("OnMouseUp", function(self, button)
-	if button == "LeftButton" and self.isMoving then
-		self:StopMovingOrSizing()
-		self.isMoving = false
-		
-		local point, _, relativePoint, x, y = self:GetPoint()
-		HunterTimerDB.point = point
-		HunterTimerDB.relativePoint = relativePoint
-		HunterTimerDB.x = x
-		HunterTimerDB.y = y
-	end
+frame:SetScript("OnUpdate", function(self, elapsed)
+	ns.OnUpdate(elapsed)
 end)

--- a/SwangThang.toc
+++ b/SwangThang.toc
@@ -1,9 +1,13 @@
 ## Interface: 20505
-## Title: SwangThang Hunter Shot Timer
-## Notes: A dynamic Auto Shot timer with latency and movement adjustments for TBC Classic.
+## Title: SwangThang
+## Notes: Melee and ranged swing timer for TBC Classic.
 ## Author: chefm4tt
 ## Version: @project-version@
 ## X-Curse-Project-ID: 1463182
-## SavedVariables: HunterTimerDB
+## SavedVariables: SwangThangDB HunterTimerDB
 
+SwangThang_Constants.lua
+SwangThang_State.lua
+SwangThang_UI.lua
+SwangThang_ClassMods.lua
 SwangThang.lua

--- a/SwangThang_ClassMods.lua
+++ b/SwangThang_ClassMods.lua
@@ -1,0 +1,90 @@
+local addonName, ns = ...
+
+-- ============================================================
+-- Class-specific visual overlays and behavior hooks.
+-- Each class mod sets callbacks on ns (OnMeleeSwing, OnRangedSwing,
+-- OnBarsCreated, OnDruidFormChange) as needed.
+-- ============================================================
+
+local function SetupRetPaladin()
+	-- Seal-twist window: gold overlay ~0.4s before swing
+	ns.OnBarsCreated = function()
+		if not ns.mhBar then return end
+		local sealZone = ns.mhBar:CreateTexture(nil, "ARTWORK")
+		sealZone:SetColorTexture(1, 0.8, 0, 0.35)
+		sealZone:SetPoint("TOPRIGHT")
+		sealZone:SetPoint("BOTTOMRIGHT")
+		sealZone:SetWidth(0)
+		ns.sealTwistZone = sealZone
+
+		local SEAL_WINDOW = 0.4
+		local origOnUpdate = ns.OnUpdate
+		ns.OnUpdate = function(elapsed)
+			origOnUpdate(elapsed)
+			if ns.sealTwistZone and ns.timers.mh.state == "swinging" and ns.mhBar then
+				local dur = ns.timers.mh.duration
+				if dur > 0 then
+					local w = (SEAL_WINDOW / dur) * ns.BAR_WIDTH
+					ns.sealTwistZone:SetWidth(math.min(w, ns.BAR_WIDTH))
+				end
+			end
+		end
+	end
+end
+
+local function SetupWarrior()
+	-- Slam pending indicator: yellow bar tint and "Slam" label while
+	-- the MH timer resets and starts fresh (visual feedback only).
+	ns.OnMeleeSwing = function(slot)
+		if slot == "mh" and ns.mhBar then
+			ns.mhBar:SetStatusBarColor(0.8, 0.8, 0.1, 1)  -- yellow
+		end
+	end
+end
+
+local function SetupEnhShaman()
+	-- Windfury 3s ICD annotation.
+	-- Track last WF proc via SPELL_EXTRA_ATTACKS (spellId 8232/8235/10486/16362/25505).
+	ns.lastWFTime = 0
+	-- ns.HandleCLEU is called by bootstrap; ClassMods gets the data via ns callbacks.
+	-- For now, record WF ICD start time when extra attacks fire.
+	local WF_IDS = { [8232]=true, [8235]=true, [10486]=true, [16362]=true, [25505]=true }
+	ns.OnBarsCreated = function()
+		-- Overlay logic handled in UpdateMeleeBar annotation; WF ICD display is
+		-- a text annotation on the MH bar (implemented as a Phase 6 detail).
+	end
+end
+
+local function SetupDruid()
+	-- Show current form in the MH bar label.
+	ns.OnDruidFormChange = function(formSpellId)
+		if not ns.mhBar then return end
+		local label = ns.DRUID_FORM_IDS[formSpellId] or "Melee"
+		ns.mhBar._text:SetText(label)
+	end
+	ns.OnBarsCreated = function()
+		-- Set initial label from current shapeshift form
+		local form = GetShapeshiftForm and GetShapeshiftForm() or 0
+		if form == 0 and ns.mhBar then
+			ns.mhBar._text:SetText("Caster")
+		end
+	end
+end
+
+-- ============================================================
+-- Dispatch: pick class mods for the current class
+-- ============================================================
+function ns.InitClassMods()
+	local class = ns.playerClass
+	if class == "PALADIN" then
+		SetupRetPaladin()
+	elseif class == "WARRIOR" then
+		SetupWarrior()
+	elseif class == "SHAMAN" then
+		SetupEnhShaman()
+	elseif class == "DRUID" then
+		SetupDruid()
+	end
+	-- HUNTER, ROGUE: no special overlays beyond dual bars
+	-- Pure casters: no bars created, no mods needed
+end

--- a/SwangThang_ClassMods.lua
+++ b/SwangThang_ClassMods.lua
@@ -59,7 +59,12 @@ local function SetupDruid()
 	-- Show current form in the MH bar label.
 	ns.OnDruidFormChange = function(formSpellId)
 		if not ns.mhBar then return end
-		local label = ns.DRUID_FORM_IDS[formSpellId] or "Melee"
+		local label
+		if formSpellId == 0 then
+			label = "Caster"
+		else
+			label = ns.DRUID_FORM_IDS[formSpellId] or "Melee"
+		end
 		ns.mhBar._text:SetText(label)
 	end
 	ns.OnBarsCreated = function()

--- a/SwangThang_Constants.lua
+++ b/SwangThang_Constants.lua
@@ -1,0 +1,81 @@
+local addonName, ns = ...
+
+-- ============================================================
+-- UI constants
+-- ============================================================
+ns.BAR_WIDTH   = 200
+ns.BAR_HEIGHT  = 20
+ns.CAST_WINDOW = 0.5    -- hidden ranged cast time in TBC
+
+-- ============================================================
+-- Spell IDs
+-- ============================================================
+ns.AUTO_SHOT_ID = 75
+
+-- Next-Melee-Attack (NMA) abilities: queue on the MH swing, fire
+-- as SPELL_DAMAGE (not SWING_DAMAGE), reset MH timer on land.
+-- OH is unaffected by NMAs.
+ns.NMA_LOOKUP = {}
+local function registerNMAs(ids)
+	for _, id in ipairs(ids) do
+		ns.NMA_LOOKUP[id] = true
+	end
+end
+
+-- Heroic Strike (Warrior)
+registerNMAs({ 78, 284, 285, 1608, 11564, 11565, 11566, 11567, 25286, 29707, 30324 })
+
+-- Cleave (Warrior)
+registerNMAs({ 845, 7369, 11608, 11609, 20569, 25231 })
+
+-- Maul (Druid — Bear)
+registerNMAs({ 6807, 6808, 6809, 8972, 9745, 9880, 9881, 26996 })
+
+-- Raptor Strike (Hunter)
+registerNMAs({ 2973, 14260, 14261, 14262, 14263, 14264, 14265, 14266, 27014 })
+
+-- Slam (Warrior) — resets MH timer on UNIT_SPELLCAST_SUCCEEDED.
+-- In original TBC, Arms Warriors timed Slam immediately after a white hit.
+-- Default: reset behavior. Verify via in-game test on Anniversary Edition.
+ns.SLAM_IDS = {}
+local SLAM_LIST = { 1464, 8820, 11604, 11605, 25241, 25242 }
+for _, id in ipairs(SLAM_LIST) do
+	ns.SLAM_IDS[id] = true
+end
+
+-- Druid form aura IDs (trigger MH timer reset on apply)
+ns.DRUID_FORM_IDS = {
+	[768]  = "Cat",       -- Cat Form
+	[5487] = "Bear",      -- Bear Form
+	[9634] = "DireBear",  -- Dire Bear Form
+}
+
+-- ============================================================
+-- Class configuration
+-- ============================================================
+-- Determines which bars to create and which events to register.
+ns.CLASS_CONFIG = {
+	HUNTER  = { ranged = true,  melee = true,  dualWield = false },
+	WARRIOR = { ranged = false, melee = true,  dualWield = true  },
+	ROGUE   = { ranged = false, melee = true,  dualWield = true  },
+	PALADIN = { ranged = false, melee = true,  dualWield = false },
+	SHAMAN  = { ranged = false, melee = true,  dualWield = true  },
+	DRUID   = { ranged = false, melee = true,  dualWield = false },
+	MAGE    = { ranged = false, melee = false, dualWield = false },
+	PRIEST  = { ranged = false, melee = false, dualWield = false },
+	WARLOCK = { ranged = false, melee = false, dualWield = false },
+}
+
+-- ============================================================
+-- SavedVariables defaults
+-- ============================================================
+ns.DB_DEFAULTS = {
+	version   = 2,
+	showMH    = true,
+	showOH    = true,
+	positions = {
+		mh     = { point = "CENTER", relativePoint = "CENTER", x = 0, y = -120 },
+		oh     = { point = "CENTER", relativePoint = "CENTER", x = 0, y = -145 },
+		ranged = { point = "CENTER", relativePoint = "CENTER", x = 0, y = -100 },
+	},
+}

--- a/SwangThang_State.lua
+++ b/SwangThang_State.lua
@@ -1,0 +1,204 @@
+local addonName, ns = ...
+
+-- ============================================================
+-- Timer State
+-- ============================================================
+-- Three independent timers: mh (main hand), oh (off hand), ranged.
+-- Each timer struct:
+--   state              "idle" | "swinging"
+--   lastSwing          GetTime() at swing start (latency-adjusted for ranged)
+--   duration           weapon speed at swing start
+--   speed              cached speed (for haste change detection)
+--   extraAttackPending counter for Sword Spec / Windfury suppression
+
+ns.timers = {
+	mh     = { state = "idle", lastSwing = 0, duration = 0, speed = 0, extraAttackPending = 0 },
+	oh     = { state = "idle", lastSwing = 0, duration = 0, speed = 0, extraAttackPending = 0 },
+	ranged = { state = "idle", lastSwing = 0, duration = 0, speed = 0 },
+}
+
+-- ============================================================
+-- State helpers
+-- ============================================================
+
+-- Start a melee or ranged swing for the given slot ("mh", "oh", "ranged").
+-- latencyAdjust: seconds to subtract from lastSwing (ranged only)
+function ns.StartSwing(slot, latencyAdjust)
+	local t = ns.timers[slot]
+	if not t then return end
+
+	local now = GetTime()
+	local speed
+
+	if slot == "ranged" then
+		local s = UnitRangedDamage("player")
+		speed = (s and s > 0) and s or 2.0
+		t.lastSwing = now - (latencyAdjust or 0)
+	else
+		local mhSpeed, ohSpeed = UnitAttackSpeed("player")
+		if slot == "mh" then
+			speed = (mhSpeed and mhSpeed > 0) and mhSpeed or 2.0
+		else
+			speed = (ohSpeed and ohSpeed > 0) and ohSpeed or 2.0
+		end
+		t.lastSwing = now
+	end
+
+	t.duration = speed
+	t.speed    = speed
+	t.state    = "swinging"
+end
+
+-- Reset a timer slot to idle.
+function ns.ResetTimer(slot)
+	local t = ns.timers[slot]
+	if not t then return end
+	t.state    = "idle"
+	t.lastSwing = 0
+	t.duration  = 0
+end
+
+-- Apply parry haste to a melee timer when the player parries an incoming attack.
+-- Formula: reduce remaining time by 40% of weapon speed, floor at 20%.
+function ns.ApplyParryHaste(slot)
+	local t = ns.timers[slot]
+	if not t or t.state ~= "swinging" then return end
+
+	local now = GetTime()
+	local remaining = (t.lastSwing + t.duration) - now
+	local floor = 0.2 * t.duration
+
+	if remaining <= floor then
+		return  -- already nearly ready; no change
+	end
+
+	local reduction = 0.4 * t.duration
+	local newRemaining = math.max(remaining - reduction, floor)
+	-- Shift lastSwing so the bar reflects the new remaining time
+	t.lastSwing = now + newRemaining - t.duration
+end
+
+-- Rescale remaining time proportionally when weapon speed changes mid-swing.
+-- Called from OnUpdate when speed difference > threshold.
+function ns.RescaleTimer(slot, newSpeed)
+	local t = ns.timers[slot]
+	if not t or t.state ~= "swinging" or t.duration <= 0 then return end
+	if math.abs(t.duration - newSpeed) < 0.01 then return end
+
+	local now = GetTime()
+	local remaining = (t.lastSwing + t.duration) - now
+	local ratio = newSpeed / t.duration
+	local newRemaining = remaining * ratio
+
+	t.duration  = newSpeed
+	t.speed     = newSpeed
+	t.lastSwing = now + newRemaining - newSpeed
+end
+
+-- ============================================================
+-- CLEU dispatch
+-- ============================================================
+
+-- Returns the current player GUID. Cached at first call since it never changes.
+local playerGUID
+local function GetPlayerGUID()
+	if not playerGUID then
+		playerGUID = UnitGUID("player")
+	end
+	return playerGUID
+end
+
+-- Main CLEU handler. Called from the bootstrap OnEvent.
+function ns.HandleCLEU()
+	local timestamp, subEvent, hideCaster,
+	      srcGUID, srcName, srcFlags, srcRaidFlags,
+	      dstGUID, dstName, dstFlags, dstRaidFlags = CombatLogGetCurrentEventInfo()
+
+	local pGUID = GetPlayerGUID()
+
+	-- ---- Player is the source ----
+	if srcGUID == pGUID then
+
+		if subEvent == "SWING_DAMAGE" then
+			-- pos 21 = isOffHand
+			local _, _, _, _, _, _, _, _, _, isOffHand = select(12, CombatLogGetCurrentEventInfo())
+			local slot = isOffHand and "oh" or "mh"
+			local t = ns.timers[slot]
+			if (t.extraAttackPending or 0) > 0 then
+				t.extraAttackPending = t.extraAttackPending - 1
+			else
+				ns.StartSwing(slot)
+				if ns.OnMeleeSwing then ns.OnMeleeSwing(slot) end
+			end
+
+		elseif subEvent == "SWING_MISSED" then
+			-- pos 12 = missType, pos 13 = isOffHand
+			local missType, isOffHand = select(12, CombatLogGetCurrentEventInfo())
+			local slot = isOffHand and "oh" or "mh"
+			local t = ns.timers[slot]
+			if (t.extraAttackPending or 0) > 0 then
+				t.extraAttackPending = t.extraAttackPending - 1
+			else
+				ns.StartSwing(slot)
+				if ns.OnMeleeSwing then ns.OnMeleeSwing(slot) end
+			end
+
+		elseif subEvent == "SPELL_CAST_SUCCESS" then
+			local spellId = select(12, CombatLogGetCurrentEventInfo())
+			if spellId == ns.AUTO_SHOT_ID then
+				-- Ranged: latency-adjusted
+				local _, _, _, latencyWorld = GetNetStats()
+				local latencySec = (latencyWorld or 0) / 1000
+				ns.StartSwing("ranged", latencySec)
+				if ns.OnRangedSwing then ns.OnRangedSwing() end
+			elseif ns.NMA_LOOKUP[spellId] then
+				-- NMA fired as SPELL_CAST_SUCCESS (belt-and-suspenders with
+				-- UNIT_SPELLCAST_SUCCEEDED; whichever fires first wins)
+				ns.StartSwing("mh")
+				if ns.OnMeleeSwing then ns.OnMeleeSwing("mh") end
+			end
+
+		elseif subEvent == "SPELL_EXTRA_ATTACKS" then
+			-- pos 15 = amount
+			local amount = select(15, CombatLogGetCurrentEventInfo())
+			-- Extra attacks can hit either hand; add to both pending counters
+			-- so whichever hand fires next absorbs them.
+			ns.timers.mh.extraAttackPending = (ns.timers.mh.extraAttackPending or 0) + (amount or 1)
+			ns.timers.oh.extraAttackPending = (ns.timers.oh.extraAttackPending or 0) + (amount or 1)
+
+		elseif subEvent == "SPELL_AURA_APPLIED" then
+			-- Druid form change → reset MH timer
+			local spellId = select(12, CombatLogGetCurrentEventInfo())
+			if ns.DRUID_FORM_IDS and ns.DRUID_FORM_IDS[spellId] then
+				ns.ResetTimer("mh")
+				ns.druidFormChangeTime = GetTime()
+				if ns.OnDruidFormChange then ns.OnDruidFormChange(spellId) end
+			end
+		end
+
+	-- ---- Player is the destination (incoming parry) ----
+	elseif dstGUID == pGUID then
+		if subEvent == "SWING_MISSED" then
+			local missType = select(12, CombatLogGetCurrentEventInfo())
+			if missType == "PARRY" then
+				ns.ApplyParryHaste("mh")
+			end
+		end
+	end
+end
+
+-- ============================================================
+-- UNIT_SPELLCAST_SUCCEEDED handler
+-- ============================================================
+-- NMA detection via UNIT_SPELLCAST_SUCCEEDED (belt-and-suspenders with CLEU).
+-- Slam detection: resets MH timer on cast completion.
+function ns.HandleSpellcastSucceeded(unit, _, spellId)
+	if unit ~= "player" then return end
+	if ns.NMA_LOOKUP[spellId] then
+		ns.StartSwing("mh")
+		if ns.OnMeleeSwing then ns.OnMeleeSwing("mh") end
+	elseif ns.SLAM_IDS[spellId] then
+		ns.StartSwing("mh")
+		if ns.OnMeleeSwing then ns.OnMeleeSwing("mh") end
+	end
+end

--- a/SwangThang_UI.lua
+++ b/SwangThang_UI.lua
@@ -1,0 +1,310 @@
+local addonName, ns = ...
+
+-- ============================================================
+-- Bar factory
+-- ============================================================
+local function CreateBar(frameName, width, height)
+	local f = CreateFrame("StatusBar", frameName, UIParent)
+	f:SetSize(width or ns.BAR_WIDTH, height or ns.BAR_HEIGHT)
+	f:SetPoint("CENTER", UIParent, "CENTER", 0, -100)
+	f:SetMovable(true)
+	f:EnableMouse(true)
+	f:RegisterForDrag("LeftButton")
+	f:SetClampedToScreen(true)
+	f:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
+	f:SetStatusBarColor(0, 1, 0, 1)
+	f:SetAlpha(0)
+
+	local bg = f:CreateTexture(nil, "BACKGROUND")
+	bg:SetAllPoints(true)
+	bg:SetColorTexture(0, 0, 0, 0.5)
+
+	local border = f:CreateTexture(nil, "OVERLAY")
+	border:SetColorTexture(0, 0, 0, 1)
+	border:SetPoint("TOPLEFT", -1, 1)
+	border:SetPoint("BOTTOMRIGHT", 1, -1)
+	border:SetDrawLayer("OVERLAY", -1)
+
+	local spark = f:CreateTexture(nil, "OVERLAY")
+	spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
+	spark:SetBlendMode("ADD")
+	spark:SetWidth(20)
+	spark:SetHeight((height or ns.BAR_HEIGHT) * 2.2)
+	spark:SetPoint("CENTER", f, "LEFT", 0, 0)
+
+	local text = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+	text:SetPoint("CENTER")
+
+	f._spark = spark
+	f._text  = text
+	f._width = width or ns.BAR_WIDTH
+	return f
+end
+
+-- ============================================================
+-- Ranged bar (preserves v1.x behavior exactly)
+-- ============================================================
+local function CreateRangedBar()
+	local f = CreateBar("SwangThangRangedBar")
+
+	-- Red "cast window" overlay
+	local castZone = f:CreateTexture(nil, "ARTWORK")
+	castZone:SetColorTexture(1, 0, 0, 0.4)
+	castZone:SetPoint("TOPRIGHT")
+	castZone:SetPoint("BOTTOMRIGHT")
+	castZone:SetWidth(0)
+	f._castZone = castZone
+
+	f._text:SetText("Auto Shot")
+	f:SetMinMaxValues(0, 1)
+	ns.rangedBar = f
+	return f
+end
+
+-- ============================================================
+-- Melee bars (MH and optional OH)
+-- ============================================================
+local function CreateMHBar()
+	local f = CreateBar("SwangThangMHBar")
+	f:SetStatusBarColor(0.8, 0.6, 0.1, 1)  -- gold
+	f._text:SetText("Main Hand")
+	f:SetMinMaxValues(0, 1)
+	ns.mhBar = f
+	return f
+end
+
+local function CreateOHBar()
+	local mh = ns.mhBar
+	local f = CreateBar("SwangThangOHBar")
+	f:SetStatusBarColor(0.5, 0.8, 0.5, 1)  -- lighter green
+	f._text:SetText("Off Hand")
+	f:SetMinMaxValues(0, 1)
+	-- Anchor OH below MH with 2px gap
+	f:ClearAllPoints()
+	f:SetPoint("TOPLEFT", mh, "BOTTOMLEFT", 0, -2)
+	f:SetPoint("TOPRIGHT", mh, "BOTTOMRIGHT", 0, -2)
+	ns.ohBar = f
+	return f
+end
+
+-- ============================================================
+-- Cast-zone visual for ranged bar
+-- ============================================================
+local function UpdateCastZoneVisual()
+	local f = ns.rangedBar
+	if not f then return end
+	local duration = ns.timers.ranged.duration
+	if duration and duration > 0 then
+		local width = (ns.CAST_WINDOW / duration) * ns.BAR_WIDTH
+		f._castZone:SetWidth(math.min(width, ns.BAR_WIDTH))
+	end
+end
+ns.UpdateCastZoneVisual = UpdateCastZoneVisual
+
+-- ============================================================
+-- Bar position save/restore
+-- ============================================================
+local function SavePosition(slot, frame)
+	if not frame then return end
+	local point, _, relativePoint, x, y = frame:GetPoint()
+	if SwangThangDB and SwangThangDB.positions then
+		SwangThangDB.positions[slot] = {
+			point = point, relativePoint = relativePoint, x = x, y = y
+		}
+	end
+end
+
+local function RestorePosition(slot, frame)
+	if not frame then return end
+	local pos = SwangThangDB and SwangThangDB.positions and SwangThangDB.positions[slot]
+	if pos then
+		frame:ClearAllPoints()
+		frame:SetPoint(pos.point, UIParent, pos.relativePoint, pos.x, pos.y)
+	end
+end
+
+-- ============================================================
+-- Drag handling (anchor bar only — OH follows MH automatically)
+-- ============================================================
+local function AttachDrag(frame, slot)
+	frame:SetScript("OnMouseDown", function(self, button)
+		if button == "LeftButton" and not self.isMoving then
+			self:StartMoving()
+			self.isMoving = true
+		end
+	end)
+	frame:SetScript("OnMouseUp", function(self, button)
+		if button == "LeftButton" and self.isMoving then
+			self:StopMovingOrSizing()
+			self.isMoving = false
+			SavePosition(slot, self)
+		end
+	end)
+end
+
+-- ============================================================
+-- Combat show/hide
+-- ============================================================
+local function ShowBars()
+	local cfg = ns.classConfig
+	if cfg and cfg.ranged and ns.rangedBar then
+		ns.rangedBar:SetAlpha(1)
+	end
+	if cfg and cfg.melee and ns.mhBar then
+		ns.mhBar:SetAlpha(1)
+	end
+	if cfg and cfg.dualWield and ns.ohBar then
+		ns.ohBar:SetAlpha(1)
+	end
+end
+
+local function HideBars()
+	if ns.rangedBar then ns.rangedBar:SetAlpha(0) end
+	if ns.mhBar     then ns.mhBar:SetAlpha(0) end
+	if ns.ohBar     then ns.ohBar:SetAlpha(0) end
+end
+
+ns.ShowBars = ShowBars
+ns.HideBars = HideBars
+
+-- ============================================================
+-- OnUpdate tick for ranged bar
+-- ============================================================
+local function UpdateRangedBar(elapsed)
+	local t = ns.timers.ranged
+	if t.state ~= "swinging" then return end
+
+	local f = ns.rangedBar
+	if not f then return end
+
+	local now = GetTime()
+
+	-- Haste rescaling: check current speed
+	local currentSpeed = UnitRangedDamage("player")
+	if currentSpeed and currentSpeed > 0 then
+		ns.RescaleTimer("ranged", currentSpeed)
+	end
+
+	-- Movement clipping in cast window
+	local cooldownEnd = t.lastSwing + t.duration - ns.CAST_WINDOW
+	if now >= cooldownEnd then
+		f:SetStatusBarColor(1, 0, 0, 1)  -- red: cast window
+		if ns.isMoving then
+			-- Pin timer at cast-window boundary
+			t.lastSwing = now - (t.duration - ns.CAST_WINDOW)
+		end
+	else
+		f:SetStatusBarColor(0, 1, 0, 1)  -- green: cooldown
+	end
+
+	local elapsed_time = now - t.lastSwing
+	local remaining = t.duration - elapsed_time
+	if remaining < 0 then remaining = 0 end
+
+	f:SetMinMaxValues(0, t.duration)
+	f:SetValue(elapsed_time)
+
+	local sparkPos = (elapsed_time / t.duration) * f._width
+	if sparkPos > f._width then sparkPos = f._width end
+	f._spark:SetPoint("CENTER", f, "LEFT", sparkPos, 0)
+	f._text:SetText(string.format("%.1f", remaining))
+end
+
+-- ============================================================
+-- OnUpdate tick for melee bars
+-- ============================================================
+local function UpdateMeleeBar(slot, frame)
+	local t = ns.timers[slot]
+	if not frame or t.state ~= "swinging" then return end
+
+	local now = GetTime()
+
+	-- Haste rescaling
+	local mhSpeed, ohSpeed = UnitAttackSpeed("player")
+	local currentSpeed = (slot == "oh") and ohSpeed or mhSpeed
+	if currentSpeed and currentSpeed > 0 then
+		-- Only rescale if UNIT_ATTACK_SPEED debounce has cleared
+		local skipUntil = ns.druidFormChangeTime and (ns.druidFormChangeTime + 0.05)
+		if not skipUntil or now > skipUntil then
+			ns.RescaleTimer(slot, currentSpeed)
+		end
+	end
+
+	local elapsed_time = now - t.lastSwing
+	local remaining = t.duration - elapsed_time
+	if remaining < 0 then remaining = 0 end
+
+	frame:SetMinMaxValues(0, t.duration)
+	frame:SetValue(elapsed_time)
+
+	local sparkPos = (elapsed_time / t.duration) * frame._width
+	if sparkPos > frame._width then sparkPos = frame._width end
+	frame._spark:SetPoint("CENTER", frame, "LEFT", sparkPos, 0)
+	frame._text:SetText(string.format("%.1f", remaining))
+end
+
+-- ============================================================
+-- OnUpdate dispatcher (called from bootstrap frame)
+-- ============================================================
+function ns.OnUpdate(elapsed)
+	UpdateRangedBar(elapsed)
+	if ns.mhBar then UpdateMeleeBar("mh", ns.mhBar) end
+	if ns.ohBar then UpdateMeleeBar("oh", ns.ohBar) end
+end
+
+-- ============================================================
+-- Bar initialization (called after SavedVariables are loaded)
+-- ============================================================
+function ns.InitBars()
+	local cfg = ns.classConfig
+	if not cfg then return end
+
+	if cfg.ranged then
+		CreateRangedBar()
+		RestorePosition("ranged", ns.rangedBar)
+		AttachDrag(ns.rangedBar, "ranged")
+	end
+
+	if cfg.melee then
+		CreateMHBar()
+		RestorePosition("mh", ns.mhBar)
+		AttachDrag(ns.mhBar, "mh")
+	end
+
+	if cfg.melee and cfg.dualWield then
+		-- Only create OH bar if player has an OH weapon equipped
+		-- (checked via UnitAttackSpeed returning a non-nil ohSpeed)
+		local _, ohSpeed = UnitAttackSpeed("player")
+		if ohSpeed then
+			CreateOHBar()
+			-- OH doesn't need drag — it follows MH automatically
+		end
+	end
+
+	-- Notify ClassMods that bars exist
+	if ns.OnBarsCreated then ns.OnBarsCreated() end
+end
+
+-- ============================================================
+-- OH bar creation on equipment change
+-- ============================================================
+function ns.UpdateOHBar()
+	local cfg = ns.classConfig
+	if not cfg or not cfg.dualWield then return end
+
+	local _, ohSpeed = UnitAttackSpeed("player")
+	if ohSpeed and not ns.ohBar then
+		CreateOHBar()
+		if ns.OnBarsCreated then ns.OnBarsCreated() end
+	elseif not ohSpeed and ns.ohBar then
+		ns.ohBar:Hide()
+		ns.ohBar = nil
+		ns.timers.oh.state = "idle"
+	end
+end
+
+-- Callbacks set by ClassMods (optional)
+ns.OnMeleeSwing  = nil
+ns.OnRangedSwing = nil
+ns.OnBarsCreated = nil
+ns.OnDruidFormChange = nil


### PR DESCRIPTION
## Summary

- Expands SwangThang from a Hunter-only auto shot timer to a full melee + ranged swing timer supporting all physical DPS classes
- 5-module architecture replaces the original single-file design
- 117/117 unit tests passing

## Classes supported

Warrior, Rogue, Paladin (Ret), Enhancement Shaman, Feral Druid, Hunter

## Key features

- Dual-wield OH tracking
- NMA (Next Melee Attack) detection with suppression
- Parry haste (reset on parry)
- Extra attack suppression
- Haste rescaling on buff gain/loss
- Druid form detection (Caster/Bear/Cat/Moonkin)
- Ret Paladin seal-twist zone overlay

Closes #1